### PR TITLE
Moves react and react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     "url": "https://github.com/kimmobrunfeldt/react-progressbar.js/issues"
   },
   "homepage": "https://github.com/kimmobrunfeldt/react-progressbar.js#readme",
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
+  },
   "dependencies": {
     "lodash.isequal": "^4.1.4",
-    "progressbar.js": "^1.0.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "progressbar.js": "^1.0.1"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -52,6 +54,8 @@
     "jscs": "^3.0.3",
     "lodash": "^4.11.1",
     "mustache": "^2.1.3",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "reactify": "^1.1.1",
     "semver": "^5.0.1",
     "shelljs": "^0.6.0",


### PR DESCRIPTION
Hey @Jivings, thanks a lot for maintaining this! :pray:

We're currently in the middle of upgrading to React 16 and wanted to first upgrade our dependencies. Unfortunately, I wasn't able to use this with React 15, so I changes the direct dependency of React to be a peer dependency.

More about this from the commit message:

> Having react and react-dom as direct dependencies of the package
> can make npm install multiple copies of React. It can also cause React
> to throw an error if another project is using a version of React other
> than the one defined in "dependencies".
>
> See:
> https://reactjs.org/warnings/refs-must-have-owner.html#multiple-copies-of-react