### PR TITLE
Update package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ only in NPM.
 CommonJS
 
 ```javascript
-var ProgressBar = require('react-progressbar.js')
+var ProgressBar = require('react-progress-bar.js')
 var Circle = ProgressBar.Circle;
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-progressbar.js",
+  "name": "react-progress-bar.js",
   "version": "0.2.1-dev",
   "description": "React wrapper for progressbar.js",
   "main": "dist/react-progressbar.js",


### PR DESCRIPTION
I noticed in #4 that we currently can't publish this with the new name `react-progress-bar.js`. This PR updates the `name` field in the `package.json` file, so the only thing we have to do to publish is to run `npm publish`.

Running `node tools/release.js` should work as well 👍 